### PR TITLE
Bug fsi

### DIFF
--- a/pyBeam/include/beam.h
+++ b/pyBeam/include/beam.h
@@ -95,6 +95,13 @@ public:
 
     inline void SetLoads(int iNode, int iDOF, passivedouble loadValue) { loadVector[iNode*nDOF + iDOF] = loadValue; }
 
+    // In FSI if Solve is called again with a new set of loads, old loadset needs to be reset
+    inline void ResetLoads() {
+        for (int iLoad = 0; iLoad < nTotalDOF; iLoad++){
+        loadVector[iLoad] = 0.0;}
+        structure->ResetForces();
+    }    
+        
     inline passivedouble ExtractDisplacements(int iNode, int iDim) {
         return AD::GetValue(structure->GetDisplacement(iNode, iDim));
     }

--- a/pyBeam/include/structure.h
+++ b/pyBeam/include/structure.h
@@ -100,6 +100,7 @@ public:
     VectorXdDiff Residual_red;  // Array of Unbalanced Forces   [relative to masters in case of RBE2]
     
     VectorXdDiff Fnom;          // Array of nominal forces
+    VectorXdDiff Fnom_old;          // Array of nominal forces  of previous FSI run 
     
     addouble YoungModulus;
     
@@ -117,10 +118,17 @@ public:
         for (int iLoad = 0; iLoad < nTotalDOF; iLoad++){Fnom(iLoad) = loadVector[iLoad];}
     }
 
+    inline void ResetForces() {
+        Fnom_old = Fnom;
+        Fnom = VectorXdDiff::Zero(nNode*6);
+    } 
+    
     inline void SetDimensionalYoungModulus(addouble val_E){ YoungModulus = val_E; }
 
     // External forces are normalized by the Young Modulus
-    inline void UpdateExtForces(addouble lambda){ Fext = lambda* Fnom / YoungModulus; }
+    //inline void UpdateExtForces(addouble lambda){ Fext = lambda* Fnom / YoungModulus; }
+    inline void UpdateExtForces(addouble lambda){       
+        Fext = ( lambda* (Fnom -Fnom_old) +Fnom_old )  / YoungModulus;}
 
     void EvalResidual(unsigned short rigid);
 

--- a/pyBeam/src/beam.cpp
+++ b/pyBeam/src/beam.cpp
@@ -151,9 +151,9 @@ void CBeamSolver::Solve(int FSIIter = 0){
     // This function set the current initial coordinates and memorizes them as the old one before the converging procedure starts
     structure->InitialCoord();
     structure->RestartCoord();
-    structure->UpdateRotationMatrix_FP();  // based on the rotational displacements
     structure->UpdateLength();
-    structure->UpdateInternalForces_FP();
+    //structure->UpdateRotationMatrix_FP();  // based on the rotational displacements    
+    //structure->UpdateInternalForces_FP();
 
     totalIter = 0;
     for  ( loadStep = 0; loadStep < input->Get_LoadSteps(); loadStep++) {
@@ -272,7 +272,8 @@ void CBeamSolver::Solve(int FSIIter = 0){
     WriteRestart();
     if (verbose){std::cout << std::endl << "--> Exiting Iterative Sequence." << std::endl;}
 
-    
+     // Resetting Fnom in case Solve is called again
+    ResetLoads();    
     
 }
 

--- a/pyBeam/src/structure.cpp
+++ b/pyBeam/src/structure.cpp
@@ -71,6 +71,7 @@ CStructure::CStructure(CInput *input, CElement **container_element, CNode **cont
 
     // Forces nodal Vector
     Fnom     =  VectorXdDiff::Zero(nNode*6);
+    Fnom_old =  VectorXdDiff::Zero(nNode*6); 
     Fext     =  VectorXdDiff::Zero(nNode*6);
     Fpenal   =  VectorXdDiff::Zero(nNode*6);
     Fint     =  VectorXdDiff::Zero(nNode*6);


### PR DESCRIPTION
This version fixes the code with the following improvements:

1) Bug correction in case of FSI: loads are reset to zero so that new loads set can be applied. Before there was just an 'entry-per-entry' overwrite. In our test cases this bug led to no problem.

2) Load-stepping in case of FSI now is performed from the old load set to the new one (and not from 0 to the new one as before). This doesn't change results but  stabilises the code avoiding all those divergence behaviours we used to have in the past.